### PR TITLE
Refactoring of JSON configuration file & Split YOLOs

### DIFF
--- a/clients/tracker_client_images.py
+++ b/clients/tracker_client_images.py
@@ -38,18 +38,18 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
         detect1 = json.load(config_file)
         log.debug("Detector config loaded.")
 
-    detect1_proc = detect1['Proc']
-    detect1_preproc = detect1['Preproc']
-    detect1_postproc = detect1['Postproc']
+    detect1_proc = detect1['proc']
+    detect1_preproc = detect1['preproc']
+    detect1_postproc = detect1['postproc']
 
     # Get parameters of the different stages of the tracking process
     with open(cfg_track) as config_file:
         track1 = json.load(config_file)
         log.debug("Tracker config loaded.")
 
-    track1_proc = track1['Proc']
-    track1_preproc = track1['Preproc']
-    track1_postproc = track1['Postproc']
+    track1_proc = track1['proc']
+    track1_preproc = track1['preproc']
+    track1_postproc = track1['postproc']
 
     # Get the classes of the object to be detected
     with open(cfg_classes) as config_file:

--- a/clients/tracker_client_images.py
+++ b/clients/tracker_client_images.py
@@ -33,6 +33,7 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
 
     log = logging.getLogger("aptitude-toolbox")
 
+    # Get parameters of the different stages of the detection process
     with open(cfg_detect) as config_file:
         detect1 = json.load(config_file)
         log.debug("Detector config loaded.")
@@ -41,6 +42,7 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
     detect1_preproc = detect1['Preproc']
     detect1_postproc = detect1['Postproc']
 
+    # Get parameters of the different stages of the tracking process
     with open(cfg_track) as config_file:
         track1 = json.load(config_file)
         log.debug("Tracker config loaded.")
@@ -49,25 +51,26 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
     track1_preproc = track1['Preproc']
     track1_postproc = track1['Postproc']
 
+    # Get the classes of the object to be detected
     with open(cfg_classes) as config_file:
         CLASSES = json.load(config_file)['classes']
         log.debug("Classes config loaded.")
 
-    # Instantiate detector
+    # Instantiate the detector
     start = default_timer()
     detection_manager = DetectionManager(DetectorFactory.create_detector(detect1_proc),
                                          detect1_preproc, detect1_postproc)
     end = default_timer()
     log.info("Detector init duration = {}s".format(str(end - start)))
 
-    # Instantiate tracker
+    # Instantiate the tracker
     start = default_timer()
     tracking_manager = TrackingManager(TrackerFactory.create_tracker(track1_proc),
                                        track1_preproc, track1_postproc)
     end = default_timer()
     log.info("Tracker init duration = {}s".format(str(end - start)))
 
-    # Get sequence, the list of images
+    # Get the sequence, the list of images in the correct order
     included_extensions = ['jpg', 'jpeg', 'bmp', 'png', 'gif']
     file_list = [f for f in os.listdir(folder_path)
                  if any(f.endswith(ext) for ext in included_extensions)]
@@ -77,6 +80,7 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
     else:
         log.error("Image list is empty, check if the input path is correct.")
 
+    # Get the first image to initialize the video dimension if not specified
     record = record_path is not None
     frame_test = ih.get_cv2_img_from_str(os.path.join(folder_path, file_list[0]))
     H, W, _ = frame_test.shape
@@ -86,11 +90,12 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
         output_video = cv2.VideoWriter(record_path, cv2.VideoWriter_fourcc(*'mp4v'), record_fps, record_size)
         log.debug("VideoWriter opened successfully.")
 
+    # Read and initialize values to display the ground truth
     if gt_path is not None and not os.path.isdir(gt_path):
         with open(gt_path, 'r') as gt:
             gt_lines = gt.readlines()
             gt_line_number = 0
-            gt_frame_num = 1  # 1 for RGB, 2 for residues
+            gt_frame_num = 1
             log.debug("Ground truth file open successfully.")
 
     warmup_time = 0
@@ -107,6 +112,7 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
 
     for image_name in tqdm(file_list_sorted):
 
+        # Check if a key was pressed but with some delay, as it resource consuming
         time_update = default_timer()
         if not headless and time_update - last_update > (1/10):
             k = cv2.waitKey(1) & 0xFF
@@ -123,9 +129,12 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
             if k == ord('p'):  # pause/play loop if 'p' key is pressed
                 is_paused = False
 
+        # Frame interval can be used to skip frames.
+        # Skip the frame is the counter is not divisible by frame_interval
         if counter % frame_interval != 0:
             continue
 
+        # Read the frame and measure elapsed time
         read_time_start = default_timer()
         frame = ih.get_cv2_img_from_str(os.path.join(folder_path, image_name))
         read_time += default_timer() - read_time_start
@@ -133,6 +142,7 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
 
         (H, W, _) = frame.shape
 
+        # Proceed to the detection & tracking
         warmup_time_start = default_timer()
         log.debug("Before detection.")
         det = detection_manager.detect(frame)
@@ -143,21 +153,21 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
         else:
             res = tracking_manager.track(det)
             log.debug("After tracking, without frames.")
+        # Don't count the time of the first 5 iteration if we consider there is a 'warmup time'
         if counter <= 5:
             warmup_time += default_timer() - warmup_time_start
 
         tot_det_time += det.detection_time
         tot_track_time += res.tracking_time
 
-        # Visualize
+        # Change dimensions of the result to match to the initial dimension of the frame
         res.change_dims(W, H)
         log.debug("Dimensions of the results changed: (W: {}, H:{}).".format(W, H))
         # print(res)
 
-        # Add to output file
+        # Add the result to the output file in MOT format
         if mot_path is not None:
             for i in range(res.number_objects):
-                # counter + 1 for RGB, +2 for residues
                 results = "{0},{1},{2},{3},{4},{5},-1,-1,-1,-1\n".format(counter + 1, res.global_IDs[i],
                                                                          res.bboxes[i][0], res.bboxes[i][1],
                                                                          res.bboxes[i][2], res.bboxes[i][3])
@@ -168,11 +178,12 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
         res.to_x1_y1_x2_y2()
         log.debug("Results converted to x1,y1,x2,y2.")
 
+        # Add GT bboxes from GT file (MOT format) to the frame
         if gt_path is not None:
-            if os.path.isdir(gt_path):  # For CSV files from Digital Twin project
-                frame = add_ground_truths(frame, image_name, gt_path, W, H)
+            # If the path is a directory, read the format of CSV files from Digital Twin project
+            if os.path.isdir(gt_path):
+                frame = add_ground_truths_DT(frame, image_name, gt_path, W, H)
             else:
-                # counter+1 for RGB, +2 for residues
                 while gt_frame_num == counter+1 and gt_line_number < len(gt_lines):
                     line = gt_lines[gt_line_number]
                     new_gt_frame_num, id, left, top, width, height, _, _, _, _ = line.split(",")
@@ -182,21 +193,30 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
                         gt_frame_num = new_gt_frame_num
                         # Don't increment gt_line_number
                         break
+
+                    # Draw a white rectangle for each bbox
                     cv2.rectangle(frame, (left, top), (left + width, top + height), (255, 255, 255), 2)
+                    # Write a text with the ground truth ID
                     # cv2.putText(frame, str(id), (left, top - 5), font, 1, (255, 255, 255), 2, line_type)
                     gt_line_number += 1
             log.debug("Ground truth bounding boxes added to the image.")
 
+        # Add the bboxes from the process to the frame
         for i in range(res.number_objects):
             id = res.global_IDs[i]
             color = [int(c) for c in COLORS[id]]
             vehicle_label = 'I: {0}, T: {1} ({2})'.format(id, CLASSES[res.class_IDs[i]], str(res.det_confs[i])[:4])
+
+            # Draw a rectangle (with a random color) for each bbox
             cv2.rectangle(frame, (round(res.bboxes[i][0]), round(res.bboxes[i][1])),
                             (round(res.bboxes[i][2]), round(res.bboxes[i][3])), color, thickness)
+
+            # Write a text with the vehicle label, the confidence score and the ID
             cv2.putText(frame, vehicle_label, (round(res.bboxes[i][0]), round(res.bboxes[i][1] - 5)),
                         font, 1, color, thickness, line_type)
         log.debug("Results bounding boxes added to the image.")
 
+        # If headless flag is absent, show the results of the process in a dedicated window
         if not headless:
             frame_display = frame
             if display_size is not None:
@@ -204,6 +224,8 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
                 log.debug("Frame resized for display")
             cv2.imshow("Result", frame_display)
             log.debug("Frame displayed.")
+
+        # If record flag is present, record the resulting frame on the disk
         if record:
             frame_record = frame
             if record_size is not None:
@@ -214,12 +236,12 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
 
         counter += 1
 
-
+    # If MOT path flag is present, write all the lines at once to save on the disk
     if mot_path is not None:
         with open(mot_path, "w") as out:
             out.writelines(output_lines)
 
-    # Not using warm-up time
+    # Display elapsed time (without taking a warm-up time into account)
     log.info("Average FPS: {}".format(str(counter / (default_timer() - before_loop))))
     log.info("Average FPS w/o read time: {}".format(str(counter / (default_timer() - before_loop - read_time))))
 
@@ -233,8 +255,8 @@ def main(cfg_detect, cfg_track, cfg_classes, folder_path, frame_interval, record
         output_video.release()
     cv2.destroyAllWindows()
 
-
-def add_ground_truths(frame, image_name, gt_folder_path, W, H):
+# This function allows to read the GT bboxes from the CSV of the Digital Twin project.
+def add_ground_truths_DT(frame, image_name, gt_folder_path, W, H):
     base_name = image_name[:-4]
     csv_file_name = os.path.join(gt_folder_path, base_name + ".csv")
     if os.path.exists(csv_file_name):
@@ -243,8 +265,10 @@ def add_ground_truths(frame, image_name, gt_folder_path, W, H):
             next(csv_reader)  # Ignore header
             for i, row in enumerate(csv_reader):
                 max_x, max_y, min_x, min_y = 0, 0, W, H
+                # Step is 2 because we read two cells at once
                 for j in range(44, 60, 2):
                     x, y = int(row[j]), int(row[j + 1])
+                    # Take the largest possible rectangle
                     if x < min_x:
                         min_x = x
                     if y < min_y:

--- a/clients/tracker_client_video.py
+++ b/clients/tracker_client_video.py
@@ -37,18 +37,18 @@ def main(cfg_detect, cfg_track, cfg_classes, video_path, frame_interval, record_
         detect1 = json.load(config_file)
         log.debug("Detector config loaded.")
 
-    detect1_proc = detect1['Proc']
-    detect1_preproc = detect1['Preproc']
-    detect1_postproc = detect1['Postproc']
+    detect1_proc = detect1['proc']
+    detect1_preproc = detect1['preproc']
+    detect1_postproc = detect1['postproc']
 
     # Get parameters of the different stages of the tracking process
     with open(cfg_track) as config_file:
         track1 = json.load(config_file)
         log.debug("Tracker config loaded.")
 
-    track1_proc = track1['Proc']
-    track1_preproc = track1['Preproc']
-    track1_postproc = track1['Postproc']
+    track1_proc = track1['proc']
+    track1_preproc = track1['preproc']
+    track1_postproc = track1['postproc']
 
     # Get the classes of the object to be detected
     with open(cfg_classes) as config_file:

--- a/configs/all-preproc-postproc.json
+++ b/configs/all-preproc-postproc.json
@@ -1,6 +1,6 @@
 {
-    "Proc": {},
-    "Preproc": {
+    "proc": {},
+    "preproc": {
         "border": {
             "centered": true
         },
@@ -16,7 +16,7 @@
             "height": 720
         }
     },
-    "Postproc": {
+    "postproc": {
         "nms": {
             "pref_implem": "Malisiewicz",
             "nms_thresh": 0.45

--- a/configs/detect-BS-frame_diff.json
+++ b/configs/detect-BS-frame_diff.json
@@ -1,24 +1,18 @@
 {
-    "Proc":{
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "BackgroundSubtractor",
-            "pref_implem": "frame_diff",
-            "model_path": "",
-            "config_path": ""
-        },
-        "BackgroundSubtractor":{
-        }
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "BackgroundSubtractor",
+        "pref_implem": "frame_diff",
+        "params": {}
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 416,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "nms": {
             "pref_implem" : "Malisiewicz",
             "nms_thresh" : 0.45

--- a/configs/detect-BS-mean.json
+++ b/configs/detect-BS-mean.json
@@ -1,24 +1,21 @@
 {
-    "Proc":{
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "BackgroundSubtractor",
-            "pref_implem": "mean"
-        },
-        "BackgroundSubtractor":{
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "BackgroundSubtractor",
+        "pref_implem": "mean",
+        "params": {
             "intensity": 50,
             "max_last_images": 50
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 416,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "nms": {
             "pref_implem" : "Malisiewicz",
             "nms_thresh" : 0.45

--- a/configs/detect-FasterRCNN.json
+++ b/configs/detect-FasterRCNN.json
@@ -5,7 +5,7 @@
         "model_type": "FasterRCNN",
         "pref_implem": "torch-resnet50",
         "params": {
-            "model_path": "./models/fasterrcnn_resnet50_fpn_coco-258fb6c6.pth\"",
+            "model_path": "./models/fasterrcnn_resnet50_fpn_coco-258fb6c6.pth",
             "input_width" : 736,
             "input_height" : 416,
             "use_coco_weights": false,

--- a/configs/detect-FasterRCNN.json
+++ b/configs/detect-FasterRCNN.json
@@ -1,27 +1,24 @@
 {
-    "Proc":{    
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "FASTERRCNN",
-            "pref_implem": "torch-resnet50",
-            "model_path": "./models/fasterrcnn_resnet50_fpn_coco-258fb6c6.pth",
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "FasterRCNN",
+        "pref_implem": "torch-resnet50",
+        "params": {
+            "model_path": "./models/fasterrcnn_resnet50_fpn_coco-258fb6c6.pth\"",
             "input_width" : 736,
-            "input_height" : 416
-        },
-        "FASTERRCNN":{
-            "use_coco_weights": true,
+            "input_height" : 416,
+            "use_coco_weights": false,
             "GPU": true
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 736,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "min_conf": 0.25,
         "nms": {
             "pref_implem" : "Malisiewicz",

--- a/configs/detect-MaskRCNN.json
+++ b/configs/detect-MaskRCNN.json
@@ -8,7 +8,7 @@
             "model_path": "./models/maskrcnn_resnet50_fpn_coco-bf2d0c1e.pth",
             "input_width" : 736,
             "input_height" : 416,
-            "use_coco_weights": true,
+            "use_coco_weights": false,
             "GPU": true
         }
     },

--- a/configs/detect-MaskRCNN.json
+++ b/configs/detect-MaskRCNN.json
@@ -1,27 +1,24 @@
 {
-    "Proc":{    
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "MRCNN",
-            "pref_implem": "torch-resnet50",
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "MaskRCNN",
+        "pref_implem": "torch-resnet50",
+        "params": {
             "model_path": "./models/maskrcnn_resnet50_fpn_coco-bf2d0c1e.pth",
             "input_width" : 736,
-            "input_height" : 416
-        },
-        "MRCNN":{
-            "use_coco_weights": false,
+            "input_height" : 416,
+            "use_coco_weights": true,
             "GPU": true
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 736,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "min_conf": 0.25,
         "nms": {
             "pref_implem" : "Malisiewicz",

--- a/configs/detect-detectron2.json
+++ b/configs/detect-detectron2.json
@@ -1,27 +1,24 @@
 {
-    "Proc":{    
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "Detectron2",
-            "pref_implem": "Default",
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "Detectron2",
+        "pref_implem": "Default",
+        "params": {
             "model_path": "./models/COCO_faster_rcnn_R_50_C4_1x_137257644.pkl",
-            "config_path": "./models/COCO_faster_rcnn_R_50_C4_1x.yaml"
-        },
-        "Detectron2":{
+            "config_path": "./models/COCO_faster_rcnn_R_50_C4_1x.yaml",
             "conf_thresh": 0.25,
             "nms_thresh": 0,
             "GPU": true
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 416,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "nms": {
             "pref_implem" : "Malisiewicz",
             "nms_thresh" : 0.45

--- a/configs/detect-yolov4.json
+++ b/configs/detect-yolov4.json
@@ -1,30 +1,27 @@
 {
-    "Proc":{    
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "YOLO4",
-            "pref_implem": "cv2-DetectionModel",
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "YOLO4",
+        "pref_implem": "cv2-DetectionModel",
+        "params": {
             "model_path": "./models/yolov4-mio.weights",
             "config_path": "./models/yolov4-mio.cfg",
             "input_width" : 416,
-            "input_height" : 416
-        },
-        "YOLO4":{
-            "conf_thresh": 0.25, 
+            "input_height" : 416,
+            "conf_thresh": 0.25,
             "nms_thresh": 0,
-            "GPU": false,
+            "GPU": true,
             "half_precision": false
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 416,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "nms": {
             "pref_implem" : "Malisiewicz",
             "nms_thresh" : 0.45

--- a/configs/detect-yolov4.json
+++ b/configs/detect-yolov4.json
@@ -4,14 +4,14 @@
             "type": "BBoxes2DDetector"
         },
         "BBoxes2DDetector":{
-            "model_type": "YOLO",
+            "model_type": "YOLO4",
             "pref_implem": "cv2-DetectionModel",
             "model_path": "./models/yolov4-mio.weights",
             "config_path": "./models/yolov4-mio.cfg",
             "input_width" : 416,
             "input_height" : 416
         },
-        "YOLO":{
+        "YOLO4":{
             "conf_thresh": 0.25, 
             "nms_thresh": 0,
             "GPU": false,

--- a/configs/detect-yolov4.json
+++ b/configs/detect-yolov4.json
@@ -10,6 +10,7 @@
             "input_width" : 416,
             "input_height" : 416,
             "conf_thresh": 0.25,
+            "nms_across_classes": true,
             "nms_thresh": 0,
             "GPU": true,
             "half_precision": false

--- a/configs/detect-yolov5.json
+++ b/configs/detect-yolov5.json
@@ -9,6 +9,7 @@
             "input_width" : 416,
             "input_height" : 416,
             "conf_thresh": 0.25,
+            "nms_across_classes": true,
             "nms_thresh": 0,
             "GPU": true
         }

--- a/configs/detect-yolov5.json
+++ b/configs/detect-yolov5.json
@@ -4,13 +4,13 @@
             "type": "BBoxes2DDetector"
         },
         "BBoxes2DDetector":{
-            "model_type": "YOLO",
+            "model_type": "YOLO5",
             "pref_implem": "torch-Ultralytics",
             "model_path": "./models/yolov5s-mio.pt",
             "input_width" : 416,
             "input_height" : 416
         },
-        "YOLO":{
+        "YOLO5":{
             "conf_thresh": 0.25, 
             "nms_thresh": 0,
             "GPU": true

--- a/configs/detect-yolov5.json
+++ b/configs/detect-yolov5.json
@@ -1,28 +1,25 @@
 {
-    "Proc":{    
-        "Detector":{
-            "type": "BBoxes2DDetector"
-        },
-        "BBoxes2DDetector":{
-            "model_type": "YOLO5",
-            "pref_implem": "torch-Ultralytics",
+    "proc":{
+        "task": "detection",
+        "output_type": "bboxes2D",
+        "model_type": "YOLO5",
+        "pref_implem": "torch-Ultralytics",
+        "params": {
             "model_path": "./models/yolov5s-mio.pt",
             "input_width" : 416,
-            "input_height" : 416
-        },
-        "YOLO5":{
-            "conf_thresh": 0.25, 
+            "input_height" : 416,
+            "conf_thresh": 0.25,
             "nms_thresh": 0,
             "GPU": true
         }
     },
-    "Preproc":{
+    "preproc":{
         "resize":{
             "width" : 416,
             "height": 416
         }
     },
-    "Postproc":{
+    "postproc":{
         "nms": {
             "pref_implem" : "Malisiewicz",
             "nms_thresh" : 0.45

--- a/configs/track-IOU.json
+++ b/configs/track-IOU.json
@@ -1,17 +1,14 @@
 {
-    "Proc":{
-        "Tracker":{
-            "type": "BBoxes2DTracker"
-        },
-        "BBoxes2DTracker":{
-            "model_type": "IOU",
-            "pref_implem": "SimpleIOU"
-        },
-        "IOU":{
+    "proc":{
+        "task": "tracking",
+        "output_type": "bboxes2D",
+        "model_type": "IOU",
+        "pref_implem": "SimpleIOU",
+        "params": {
             "min_hits": 3,
             "iou_thresh": 0.3
         }
     },
-    "Preproc":{},
-    "Postproc":{}
+    "preproc":{},
+    "postproc":{}
 }

--- a/configs/track-KIOU.json
+++ b/configs/track-KIOU.json
@@ -1,18 +1,15 @@
 {
-    "Proc":{
-        "Tracker":{
-            "type": "BBoxes2DTracker"
-        },
-        "BBoxes2DTracker":{
-            "model_type": "IOU",
-            "pref_implem": "KIOU"
-        },
-        "IOU":{
+    "proc":{
+        "task": "tracking",
+        "output_type": "bboxes2D",
+        "model_type": "IOU",
+        "pref_implem": "KIOU",
+        "params": {
             "min_hits": 3,
             "iou_thresh": 0.3,
             "max_age": 30
         }
     },
-    "Preproc":{},
-    "Postproc":{}
+    "preproc":{},
+    "postproc":{}
 }

--- a/configs/track-centroid.json
+++ b/configs/track-centroid.json
@@ -1,16 +1,13 @@
 {
-    "Proc":{
-        "Tracker":{
-            "type": "BBoxes2DTracker"
-        },
-        "BBoxes2DTracker":{
-            "model_type": "Centroid",
-            "pref_implem": "Rosebrock"
-        },
-        "Centroid":{
+    "proc":{
+        "task": "tracking",
+        "output_type": "bboxes2D",
+        "model_type": "Centroid",
+        "pref_implem": "Rosebrock",
+        "params": {
             "max_age": 10
         }
     },
-    "Preproc":{},
-    "Postproc":{}
+    "preproc":{},
+    "postproc":{}
 }

--- a/configs/track-deepsort.json
+++ b/configs/track-deepsort.json
@@ -1,13 +1,10 @@
 {
-    "Proc":{    
-        "Tracker":{
-            "type": "BBoxes2DTracker"
-        },
-        "BBoxes2DTracker":{
-            "model_type": "DeepSORT",
-            "pref_implem": "Leonlok"
-        },
-        "DeepSORT":{
+    "proc":{
+        "task": "tracking",
+        "output_type": "bboxes2D",
+        "model_type": "DeepSORT",
+        "pref_implem": "Leonlok",
+        "params": {
             "model_path": "./models/cosine_metric_DETRAC_LeonLok.pb",
             "max_age": 30,
             "min_hits": 3,
@@ -18,10 +15,9 @@
             "avg_det_conf": true,
             "avg_det_conf_thresh": 0.25,
             "most_common_class": true
-            
         }
     },
-    "Preproc":{
+    "preproc":{
         "border":{
             "centered": false
         },
@@ -30,5 +26,5 @@
             "height": 416
         }
     },
-    "Postproc":{}
+    "postproc":{}
 }

--- a/configs/track-sort.json
+++ b/configs/track-sort.json
@@ -1,19 +1,16 @@
 {
-    "Proc":{    
-        "Tracker":{
-            "type": "BBoxes2DTracker"
-        },
-        "BBoxes2DTracker":{
-            "model_type": "SORT",
-            "pref_implem": "Abewley"
-        },
-        "SORT":{
+    "proc":{
+        "task": "tracking",
+        "output_type": "bboxes2D",
+        "model_type": "SORT",
+        "pref_implem": "Abewley",
+        "params":{
             "max_age": 10, 
             "min_hits": 3,
             "iou_thresh": 0.3,
             "memory_fade": 1.0
         }
     },
-    "Preproc":{},
-    "Postproc":{}
+    "preproc":{},
+    "postproc":{}
 }

--- a/docs/bboxes_2d_detector.rst
+++ b/docs/bboxes_2d_detector.rst
@@ -29,15 +29,15 @@ faster_rcnn
 mask_rcnn
 """"""""""""""""""""""""
 
-.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.mask_rcnn.mrcnn
+.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.mask_rcnn.mask_rcnn
 
 yolo_2_3_4
 """"""""""""""""""""""""
 
-.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo_2_3_4.yolo_2_3_4
+.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo4.yolo4
 
 yolo_5
 """"""""""""""""""""""""
 
-.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo_5.yolo_5
+.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo5.yolo5
 

--- a/docs/bboxes_2d_detector.rst
+++ b/docs/bboxes_2d_detector.rst
@@ -31,9 +31,13 @@ mask_rcnn
 
 .. automodule:: pytb.detection.bboxes.bboxes_2d_detector.mask_rcnn.mrcnn
 
-yolo
+yolo_2_3_4
 """"""""""""""""""""""""
 
-.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo.yolo
+.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo_2_3_4.yolo_2_3_4
 
+yolo_5
+""""""""""""""""""""""""
+
+.. automodule:: pytb.detection.bboxes.bboxes_2d_detector.yolo_5.yolo_5
 

--- a/pytb/detection/bboxes/bboxes_2d_detector/background_subtractor/background_subtractor.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/background_subtractor/background_subtractor.py
@@ -45,11 +45,11 @@ class BackgroundSubtractor(BBoxes2DDetector):
         else:
             assert False, "[ERROR] Unknown implementation of BackgroundSubtractor: {}".format(self.pref_implem)
 
-    def detect(self, frame: np.ndarray) -> BBoxes2D:
+    def detect(self, frame: np.array) -> BBoxes2D:
         """Performs an inference using a background subtraction method on the given frame.
 
         Args:
-            frame (np.ndarray): The frame to infer detections from a background substractor.
+            frame (np.array): The frame to infer detections from a background substractor.
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.

--- a/pytb/detection/bboxes/bboxes_2d_detector/background_subtractor/background_subtractor.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/background_subtractor/background_subtractor.py
@@ -17,29 +17,29 @@ log = logging.getLogger("aptitude-toolbox")
 
 class BackgroundSubtractor(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the BackgroundSubstractor detector parameters
+            proc_parameters (dict): A dictionary containing the BackgroundSubstractor detector parameters
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
         # From cv2.approxPolyDP: Specifies the approximation accuracy. 
         # This is the maximum distance between the original curve and its approximation.
-        self.contour_thresh = detector_parameters["BackgroundSubtractor"].get("contour_thresh", 3)
+        self.contour_thresh = proc_parameters["params"].get("contour_thresh", 3)
 
         # The minimum intensity of the pixels in the foreground image.
-        self.intensity = detector_parameters["BackgroundSubtractor"].get("intensity", 50)
+        self.intensity = proc_parameters["params"].get("intensity", 50)
 
         log.debug("BackgroundSubtractor {} implementation selected.".format(self.pref_implem))
         if self.pref_implem == "mean" or self.pref_implem == "median":
             # If the pref_implem is "mean" or "median", the results will be based on the mean or median
             # values of the previous images. 
-            self.max_last_images = detector_parameters["BackgroundSubtractor"].get("max_last_images", 50)
+            self.max_last_images = proc_parameters["params"].get("max_last_images", 50)
             self.last_images = []
 
         elif self.pref_implem == "frame_diff":
-            # IF the pref_implem is "frame_diff", the results will be solely based on the previous image.
+            # If the pref_implem is "frame_diff", the results will be solely based on the previous image.
             self.prev_image = None
 
         else:

--- a/pytb/detection/bboxes/bboxes_2d_detector/bboxes_2d_detector.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/bboxes_2d_detector.py
@@ -13,36 +13,36 @@ from pytb.output.bboxes_2d import BBoxes2D
 
 class BBoxes2DDetector(Detector, ABC):
 
-    def __init__(self, detector_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """
         This class encompasses the attributes that are common to most detectors of 2D bounding boxes.
         Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the parameters of the desired detector.
+            proc_parameters (dict): A dictionary containing the parameters of the desired detector.
         """
         super().__init__()
 
         # A detector can have multiple implementations (e.g. in different frameworks),
         # this parameter allows to choose one (required).
-        self.pref_implem = detector_parameters["BBoxes2DDetector"]["pref_implem"]
+        self.pref_implem = proc_parameters["pref_implem"]
         
         # A detector usually comes with its weight and a configuration file.
         # Those are the path to those files (required in some implementations).
-        self.model_path = detector_parameters["BBoxes2DDetector"].get("model_path", "")
-        self.config_path = detector_parameters["BBoxes2DDetector"].get("config_path", "")
+        self.model_path = proc_parameters["params"].get("model_path", "")
+        self.config_path = proc_parameters["params"].get("config_path", "")
         
         # The input path of the image in the detector.
         # This allows to setup the first layers of the network to match the image shape.
-        self.input_width = detector_parameters["BBoxes2DDetector"].get("input_width", 416)
-        self.input_height = detector_parameters["BBoxes2DDetector"].get("input_height", 416)
+        self.input_width = proc_parameters["params"].get("input_width", 416)
+        self.input_height = proc_parameters["params"].get("input_height", 416)
 
     @abstractmethod
-    def detect(self, org_frame: np.ndarray) -> BBoxes2D:
+    def detect(self, org_frame: np.array) -> BBoxes2D:
         """Performs an inference on the given frame. 
 
         Args:
-            org_frame (np.ndarray): The given frame to infer detections
+            org_frame (np.array): The given frame to infer detections
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying detected objects of the detected objects

--- a/pytb/detection/bboxes/bboxes_2d_detector/bboxes_2d_detector.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/bboxes_2d_detector.py
@@ -16,7 +16,7 @@ class BBoxes2DDetector(Detector, ABC):
     def __init__(self, detector_parameters: dict):
         """
         This class encompasses the attributes that are common to most detectors of 2D bounding boxes.
-        Initiliazes the detector with the given parameters.
+        Initializes the detector with the given parameters.
 
         Args:
             detector_parameters (dict): A dictionary containing the parameters of the desired detector.

--- a/pytb/detection/bboxes/bboxes_2d_detector/detectron2/detectron2.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/detectron2/detectron2.py
@@ -61,7 +61,7 @@ class Detectron2(BBoxes2DDetector):
         """Performs a Detectron2 inference on the given frame.
 
         Args:
-            frame (np): The frame to infer Detectron2 detections
+            frame (np.array): The frame to infer Detectron2 detections
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.

--- a/pytb/detection/bboxes/bboxes_2d_detector/detectron2/detectron2.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/detectron2/detectron2.py
@@ -16,25 +16,26 @@ import logging
 
 log = logging.getLogger("aptitude-toolbox")
 
+
 class Detectron2(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the Detectron2 detector parameters
+            proc_parameters (dict): A dictionary containing the Detectron2 detector parameters
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
         
         # The minimum confidence threshold of the detected objects if the implementation allows to provide one.
-        self.conf_thresh = detector_parameters["Detectron2"].get("conf_thresh", 0)
+        self.conf_thresh = proc_parameters["params"].get("conf_thresh", 0)
 
         # The minimum non-max suppression threshold of the detected objects if the implementation allows to provide one.
         # The non-max suppression can be implemented in multiple ways, results can vary.
-        self.nms_thresh = detector_parameters["Detectron2"].get("nms_thresh", 0)
+        self.nms_thresh = proc_parameters["params"].get("nms_thresh", 0)
 
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["Detectron2"].get("GPU", False)
+        self.gpu = proc_parameters["params"].get("GPU", False)
 
         log.debug("Detectron2 {} implementation selected.".format(self.pref_implem))
         if self.pref_implem == "Default":
@@ -56,11 +57,11 @@ class Detectron2(BBoxes2DDetector):
         else:
             assert False, "[ERROR] Unknown implementation of Detectron2: {}".format(self.pref_implem)
 
-    def detect(self, org_frame: np.ndarray) -> BBoxes2D:
+    def detect(self, org_frame: np.array) -> BBoxes2D:
         """Performs a Detectron2 inference on the given frame.
 
         Args:
-            frame (np.ndarray): The frame to infer Detectron2 detections
+            frame (np): The frame to infer Detectron2 detections
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.

--- a/pytb/detection/bboxes/bboxes_2d_detector/faster_rcnn/faster_rcnn.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/faster_rcnn/faster_rcnn.py
@@ -16,20 +16,21 @@ import logging
 
 log = logging.getLogger("aptitude-toolbox")
 
-class FASTERRCNN(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
+class FasterRCNN(BBoxes2DDetector):
+
+    def __init__(self, proc_parameters: dict):
         """Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the FasterRCNN parameters.
+            proc_parameters (dict): A dictionary containing the FasterRCNN parameters.
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
         # Whether to use the default weights available on PyTorch
-        self.use_coco = detector_parameters["FASTERRCNN"].get("use_coco_weights", True)
+        self.use_coco = proc_parameters["params"].get("use_coco_weights", True)
         
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["FASTERRCNN"].get("GPU", False)
+        self.gpu = proc_parameters["params"].get("GPU", False)
 
         log.debug("GPU set to {}.".format(self.gpu))
 
@@ -53,11 +54,11 @@ class FASTERRCNN(BBoxes2DDetector):
         else:
             assert False, "[ERROR] Unknown implementation of Faster-RCNN: {}".format(self.pref_implem)
 
-    def detect(self, frame: np.ndarray) -> BBoxes2D:
+    def detect(self, frame: np.array) -> BBoxes2D:
         """Performs a Faster-RCNN inference on the given frame.
 
         Args:
-            frame (np.ndarray): The frame to infer Faster-RCNN detections
+            frame (np.array): The frame to infer Faster-RCNN detections
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.

--- a/pytb/detection/bboxes/bboxes_2d_detector/mask_rcnn/mask_rcnn.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/mask_rcnn/mask_rcnn.py
@@ -16,20 +16,21 @@ import logging
 
 log = logging.getLogger("aptitude-toolbox")
 
-class MRCNN(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
+class MaskRCNN(BBoxes2DDetector):
+
+    def __init__(self, proc_parameters: dict):
         """Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the MaskRCNN parameters.
+            proc_parameters (dict): A dictionary containing the MaskRCNN parameters.
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
         # Whether to use the default weights available on PyTorch
-        self.use_coco = detector_parameters["MRCNN"].get("use_coco_weights", True)
+        self.use_coco = proc_parameters["params"].get("use_coco_weights", True)
 
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["MRCNN"].get("GPU", False)
+        self.gpu = proc_parameters["params"].get("GPU", False)
 
         log.debug("GPU set to {}.".format(self.gpu))
 

--- a/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
@@ -4,13 +4,13 @@ from pytb.output.bboxes_2d import BBoxes2D
 from timeit import default_timer
 
 import cv2
-import torch
 import numpy as np
 import logging
 
 log = logging.getLogger("aptitude-toolbox")
 
-class YOLO(BBoxes2DDetector):
+
+class YOLO4(BBoxes2DDetector):
 
     def __init__(self, detector_parameters: dict):
         """Initializes the detector with the given parameters.
@@ -21,27 +21,25 @@ class YOLO(BBoxes2DDetector):
         super().__init__(detector_parameters)
 
         # The minimum confidence threshold of the detected objects if the implementation allows to provide one.
-        self.conf_thresh = detector_parameters["YOLO"].get("conf_thresh", 0)
+        self.conf_thresh = detector_parameters["YOLO4"].get("conf_thresh", 0)
         
         # The minimum non-max suppression threshold of the detected objects if the implementation allows to provide one.
         # The non-max suppression can be implemented in multiple ways, results can vary.
-        self.nms_thresh = detector_parameters["YOLO"].get("nms_thresh", 0)
+        self.nms_thresh = detector_parameters["YOLO4"].get("nms_thresh", 0)
         
-        # Whether to perfrom the NMS algorithm across the different classes of object or separately.
-        self.nms_across_classes = detector_parameters["YOLO"].get("nms_across_classes", True)
+        # Whether to perform the NMS algorithm across the different classes of object or separately.
+        self.nms_across_classes = detector_parameters["YOLO4"].get("nms_across_classes", True)
         
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["YOLO"].get("GPU", False)
+        self.gpu = detector_parameters["YOLO4"].get("GPU", False)
         
         # Whether to use the half precision capability of the recent GPU cards. 
-        self.half_precision = detector_parameters["YOLO"].get("half_precision", False)
+        self.half_precision = detector_parameters["YOLO4"].get("half_precision", False)
 
-        log.debug("GPU set to {} and half precision set to {}."
-                  .format(self.gpu, self.half_precision))
-
-        log.debug("YOLO {} implementation selected.".format(self.pref_implem))
+        log.debug("GPU set to {} and half precision set to {}.".format(self.gpu, self.half_precision))
+        log.debug("YOLOv2-3-4 {} implementation selected.".format(self.pref_implem))
         
-        # implementation for YOLOv2-4 from OpenCV. 
+        # Implementation for YOLOv2-3-4 from OpenCV.
         # This implementation is slightly faster than cv2-Readnet but is a bit more 'blackbox'.
         if self.pref_implem == "cv2-DetectionModel":
             self.net = cv2.dnn_DetectionModel(self.model_path, self.config_path)
@@ -51,22 +49,12 @@ class YOLO(BBoxes2DDetector):
             self.net.setNmsAcrossClasses(self.nms_across_classes)
             self._setup_cv2()
 
-        # implementation for YOLOv2-4 from OpenCV. 
-        # This implementation is slightly slower than cv2-DetectionModel but outputs a bit more details about the predictions.
+        # Implementation for YOLOv2-3-4 from OpenCV.
+        # This implementation is slightly slower than cv2-DetectionModel
+        # but outputs a bit more details about the predictions.
         elif self.pref_implem == "cv2-ReadNet":
             self.net = cv2.dnn.readNet(self.model_path, self.config_path)
             self._setup_cv2()
-
-        # implementation for YOLOv5. YOLOv5 is not the actual successor of YOLOv4
-        elif self.pref_implem == "torch-Ultralytics":
-            self.net = torch.hub.load('ultralytics/yolov5:v6.0', 'custom', path=self.model_path, verbose=False)
-            if self.gpu:
-                self.net.cuda()
-            else:
-                self.net.cpu()
-            self.net.conf = self.conf_thresh
-            self.net.iou = self.nms_thresh
-            self.net.agnostic = self.nms_across_classes
 
         else:
             assert False, "[ERROR] Unknown implementation of YOLO: {}".format(self.pref_implem)
@@ -89,9 +77,6 @@ class YOLO(BBoxes2DDetector):
             blob = cv2.dnn.blobFromImage(frame, 1 / 255.0, (self.input_width, self.input_height),
                                          swapRB=True, crop=False)
             output = self._detect_cv2_read_net(blob)
-
-        elif self.pref_implem == self.pref_implem == "torch-Ultralytics":
-            output = self._detect_torch_ultralytics(frame[..., ::-1])  # BGR to RGB
 
         else:
             assert False, "[ERROR] Unknown implementation of YOLO: {}".format(self.pref_implem)
@@ -117,10 +102,10 @@ class YOLO(BBoxes2DDetector):
             log.debug("OpenCV with DNN_BACKEND_OPENCV and target CPU.")
 
     def _detect_cv2_detection_model(self, cv2_org_frame: np.array) -> BBoxes2D:
-        """Performs a YOLOv2-4 inference on the given frame using cv2-DetectionModel of openCV.
+        """Performs a YOLOv2-3-4 inference on the given frame using cv2-DetectionModel of openCV.
 
         Args:
-            frame (np.array): The frame to infer YOLOv2-4 detections.
+            frame (np.array): The frame to infer YOLOv2-3-4 detections.
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.
@@ -143,7 +128,7 @@ class YOLO(BBoxes2DDetector):
         """Performs a YOLOv2-4 inference on the given frame using cv2-ReadNet of openCV.
 
         Args:
-            frame (Any): The frame to infer YOLOv2-4 detections.
+            frame (Any): The frame to infer YOLOv2-3-4 detections.
 
         Returns:
             BBoxes2D: A set of 2D bounding boxes identifying the detected objects.
@@ -177,24 +162,3 @@ class YOLO(BBoxes2DDetector):
 
         return BBoxes2D((end - start), np.array(boxes), np.array(classes), np.array(confidences),
                         self.input_width, self.input_height)
-
-    def _detect_torch_ultralytics(self, org_frame: np.array) -> BBoxes2D:
-        """Performs a YOLOv5 inference on the given frame using ultralytic on PyTorch.
-
-        Args:
-            frame (np.array): The frame to infer YOLOv5 detections.
-
-        Returns:
-            BBoxes2D: A set of 2D bounding boxes identifying the detected objects.
-        """
-        start = default_timer()
-        output = self.net(org_frame, size=self.input_width)
-        end = default_timer()
-
-        # Get results on CPU
-        results = np.array(output.xyxy[0].cpu())
-
-        bboxes = BBoxes2D((end - start), results[:, 0:4], results[:, 5].astype(int), results[:, 4],
-                          self.input_width, self.input_height, "x1_y1_x2_y2")
-        bboxes.to_xt_yt_w_h()
-        return bboxes

--- a/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
@@ -12,29 +12,31 @@ log = logging.getLogger("aptitude-toolbox")
 
 class YOLO4(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
-        """Initializes the detector with the given parameters.
+    def __init__(self, proc_parameters: dict):
+        """This class can be used for YOLO v2, v3, v4 models from Darknet.
+
+        Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the YOLO detector parameters
+            proc_parameters (dict): A dictionary containing the YOLO detector parameters
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
 
         # The minimum confidence threshold of the detected objects if the implementation allows to provide one.
-        self.conf_thresh = detector_parameters["YOLO4"].get("conf_thresh", 0)
+        self.conf_thresh = proc_parameters["params"].get("conf_thresh", 0)
         
         # The minimum non-max suppression threshold of the detected objects if the implementation allows to provide one.
         # The non-max suppression can be implemented in multiple ways, results can vary.
-        self.nms_thresh = detector_parameters["YOLO4"].get("nms_thresh", 0)
+        self.nms_thresh = proc_parameters["params"].get("nms_thresh", 0)
         
         # Whether to perform the NMS algorithm across the different classes of object or separately.
-        self.nms_across_classes = detector_parameters["YOLO4"].get("nms_across_classes", True)
+        self.nms_across_classes = proc_parameters["params"].get("nms_across_classes", True)
         
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["YOLO4"].get("GPU", False)
+        self.gpu = proc_parameters["params"].get("GPU", False)
         
         # Whether to use the half precision capability of the recent GPU cards. 
-        self.half_precision = detector_parameters["YOLO4"].get("half_precision", False)
+        self.half_precision = proc_parameters["params"].get("half_precision", False)
 
         log.debug("GPU set to {} and half precision set to {}.".format(self.gpu, self.half_precision))
         log.debug("YOLOv2-3-4 {} implementation selected.".format(self.pref_implem))

--- a/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/yolo4/yolo4.py
@@ -138,7 +138,7 @@ class YOLO4(BBoxes2DDetector):
         # Detect objects
         self.net.setInput(blob_org_frame)
         layer_names = self.net.getLayerNames()
-        output_layers = [layer_names[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
+        output_layers = [layer_names[i - 1] for i in self.net.getUnconnectedOutLayers()]
 
         # Inference
         start = default_timer()

--- a/pytb/detection/bboxes/bboxes_2d_detector/yolo5/yolo5.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/yolo5/yolo5.py
@@ -1,0 +1,74 @@
+from pytb.detection.bboxes.bboxes_2d_detector.bboxes_2d_detector import BBoxes2DDetector
+from pytb.output.bboxes_2d import BBoxes2D
+
+from timeit import default_timer
+
+import torch
+import numpy as np
+import logging
+
+log = logging.getLogger("aptitude-toolbox")
+
+
+class YOLO5(BBoxes2DDetector):
+
+    def __init__(self, detector_parameters: dict):
+        """Initializes the detector with the given parameters.
+
+        Args:
+            detector_parameters (dict): A dictionary containing the YOLO detector parameters
+        """
+        super().__init__(detector_parameters)
+
+        # The minimum confidence threshold of the detected objects if the implementation allows to provide one.
+        self.conf_thresh = detector_parameters["YOLO5"].get("conf_thresh", 0)
+
+        # The minimum non-max suppression threshold of the detected objects if the implementation allows to provide one.
+        # The non-max suppression can be implemented in multiple ways, results can vary.
+        self.nms_thresh = detector_parameters["YOLO5"].get("nms_thresh", 0)
+
+        # Whether to perform the NMS algorithm across the different classes of object or separately.
+        self.nms_across_classes = detector_parameters["YOLO5"].get("nms_across_classes", True)
+
+        # Whether to use the GPU if available.
+        self.gpu = detector_parameters["YOLO5"].get("GPU", False)
+
+        log.debug("GPU set to {}" .format(self.gpu))
+        log.debug("YOLOv5 {} implementation selected.".format(self.pref_implem))
+
+        # implementation for YOLOv5. YOLOv5 is not the actual successor of YOLOv4
+        if self.pref_implem == "torch-Ultralytics":
+            self.net = torch.hub.load('ultralytics/yolov5:v6.0', 'custom', path=self.model_path, verbose=False)
+            if self.gpu:
+                self.net.cuda()
+            else:
+                self.net.cpu()
+            self.net.conf = self.conf_thresh
+            self.net.iou = self.nms_thresh
+            self.net.agnostic = self.nms_across_classes
+
+        else:
+            assert False, "[ERROR] Unknown implementation of YOLO: {}".format(self.pref_implem)
+
+    def detect(self, frame: np.array) -> BBoxes2D:
+        """Performs a YOLOv5 inference on the given frame using ultralytics on PyTorch.
+
+        Args:
+            frame (np.array): The frame to infer YOLOv5 detections.
+
+        Returns:
+            BBoxes2D: A set of 2D bounding boxes identifying the detected objects.
+        """
+        org_frame = frame[..., ::-1]  # BGR to RGB
+
+        start = default_timer()
+        output = self.net(org_frame, size=self.input_width)
+        end = default_timer()
+
+        # Get results on CPU
+        results = np.array(output.xyxy[0].cpu())
+
+        bboxes = BBoxes2D((end - start), results[:, 0:4], results[:, 5].astype(int), results[:, 4],
+                          self.input_width, self.input_height, "x1_y1_x2_y2")
+        bboxes.to_xt_yt_w_h()
+        return bboxes

--- a/pytb/detection/bboxes/bboxes_2d_detector/yolo5/yolo5.py
+++ b/pytb/detection/bboxes/bboxes_2d_detector/yolo5/yolo5.py
@@ -12,26 +12,26 @@ log = logging.getLogger("aptitude-toolbox")
 
 class YOLO5(BBoxes2DDetector):
 
-    def __init__(self, detector_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes the detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary containing the YOLO detector parameters
+            proc_parameters (dict): A dictionary containing the YOLO detector parameters
         """
-        super().__init__(detector_parameters)
+        super().__init__(proc_parameters)
 
         # The minimum confidence threshold of the detected objects if the implementation allows to provide one.
-        self.conf_thresh = detector_parameters["YOLO5"].get("conf_thresh", 0)
+        self.conf_thresh = proc_parameters["params"].get("conf_thresh", 0)
 
         # The minimum non-max suppression threshold of the detected objects if the implementation allows to provide one.
         # The non-max suppression can be implemented in multiple ways, results can vary.
-        self.nms_thresh = detector_parameters["YOLO5"].get("nms_thresh", 0)
+        self.nms_thresh = proc_parameters["params"].get("nms_thresh", 0)
 
         # Whether to perform the NMS algorithm across the different classes of object or separately.
-        self.nms_across_classes = detector_parameters["YOLO5"].get("nms_across_classes", True)
+        self.nms_across_classes = proc_parameters["params"].get("nms_across_classes", True)
 
         # Whether to use the GPU if available.
-        self.gpu = detector_parameters["YOLO5"].get("GPU", False)
+        self.gpu = proc_parameters["params"].get("GPU", False)
 
         log.debug("GPU set to {}" .format(self.gpu))
         log.debug("YOLOv5 {} implementation selected.".format(self.pref_implem))

--- a/pytb/detection/detection_manager.py
+++ b/pytb/detection/detection_manager.py
@@ -33,7 +33,7 @@ class DetectionManager:
             postprocess_parameters (dict): A dictionary containing the thresholds to filter out the results of the detection. 
 
         Returns:
-            Detection: An initalized DetectionManager that can be called on each frame using `detect` method.
+            Detection: An initialized DetectionManager that can be called on each frame using `detect` method.
         """
         assert val.validate_preprocess_parameters(preprocess_parameters), \
             "[ERROR] Invalid Preproc parameter(s) detected, check any error reported above for details."

--- a/pytb/detection/detector.py
+++ b/pytb/detection/detector.py
@@ -13,12 +13,12 @@ from pytb.output.detection import Detection
 class Detector(ABC):
 
     @abstractmethod
-    def detect(self, org_frame: np.ndarray) -> Detection:
+    def detect(self, org_frame: np.array) -> Detection:
         """
         Performs an inference on the given frame. 
 
         Args:
-            org_frame (np.ndarray): The given frame to infer detections
+            org_frame (np.array): The given frame to infer detections
 
         Returns:
             Detection: A set of detections of the detected objects

--- a/pytb/detection/detector_factory.py
+++ b/pytb/detection/detector_factory.py
@@ -15,61 +15,60 @@ log = logging.getLogger("aptitude-toolbox")
 class DetectorFactory:
 
     @staticmethod
-    def create_detector(detector_parameters: dict) -> Detector:
+    def create_detector(proc_parameters: dict) -> Detector:
         """
         Creates a detector given a dictionary of parameters 
         provided that the defined parameters are valid. 
         Otherwise, an error message is given indicating the invalid parameters.
-        It first branches on the detector type (e.g. `BBoxes2DDetector`) 
-        and then follow the chain to initialize the required detector.
+        Based on a model type and an implementation, it initializes the appropriate detector with the given parameters.
 
         Args:
-            detector_parameters (dict): A dictionary describing the detector to initialize.
+            proc_parameters (dict): A dictionary describing the detector to initialize.
 
         Returns:
             Detection: A concrete implementation of a Detector (e.g YOLO).
         """
-        # assert val.validate_detector_parameters(detector_parameters), \
+        # assert val.validate_proc_parameters(proc_parameters), \
         #     "[ERROR] Invalid Proc (detector) parameter(s) detected, check the above for details."
-        det_type = detector_parameters["Detector"]["type"]
+        output_type = proc_parameters["output_type"]
 
-        if det_type == "BBoxes2DDetector":
-            return DetectorFactory._bboxes_2d_detector(detector_parameters)
+        if output_type == "bboxes2D":
+            return DetectorFactory._bboxes_2d_detector(proc_parameters)
 
-        elif det_type == "PoseDetector":
-            return DetectorFactory._pose_detector(detector_parameters)
+        elif output_type == "pose":
+            return DetectorFactory._pose_detector(proc_parameters)
 
     @staticmethod
-    def _bboxes_2d_detector(detector_parameters: dict) -> BBoxes2DDetector:
+    def _bboxes_2d_detector(proc_parameters: dict) -> BBoxes2DDetector:
         """
         Creates a `BBoxes2DDetector` given a dictionary of parameters.
         It then branches on the model type to initialize a concrete detector implementation (e.g YOLO).
         """
-        model_type = detector_parameters["BBoxes2DDetector"]["model_type"]
+        model_type = proc_parameters["model_type"]
 
         log.info("Model type {} selected.".format(model_type))
         if model_type == "YOLO4":
             from pytb.detection.bboxes.bboxes_2d_detector.yolo4.yolo4 import YOLO4
-            return YOLO4(detector_parameters)
+            return YOLO4(proc_parameters)
         if model_type == "YOLO5":
             from pytb.detection.bboxes.bboxes_2d_detector.yolo5.yolo5 import YOLO5
-            return YOLO5(detector_parameters)
+            return YOLO5(proc_parameters)
         if model_type == "Detectron2":
             from pytb.detection.bboxes.bboxes_2d_detector.detectron2.detectron2 import Detectron2
-            return Detectron2(detector_parameters)
-        if model_type == "MRCNN":
-            from pytb.detection.bboxes.bboxes_2d_detector.mask_rcnn.mrcnn import MRCNN
-            return MRCNN(detector_parameters)
-        if model_type == "FASTERRCNN":
-            from pytb.detection.bboxes.bboxes_2d_detector.faster_rcnn.faster_rcnn import FASTERRCNN
-            return FASTERRCNN(detector_parameters)
+            return Detectron2(proc_parameters)
+        if model_type == "MaskRCNN":
+            from pytb.detection.bboxes.bboxes_2d_detector.mask_rcnn.mask_rcnn import MaskRCNN
+            return MaskRCNN(proc_parameters)
+        if model_type == "FasterRCNN":
+            from pytb.detection.bboxes.bboxes_2d_detector.faster_rcnn.faster_rcnn import FasterRCNN
+            return FasterRCNN(proc_parameters)
         if model_type == "BackgroundSubtractor":
             from pytb.detection.bboxes.bboxes_2d_detector.background_subtractor.background_subtractor \
                 import BackgroundSubtractor
-            return BackgroundSubtractor(detector_parameters)
+            return BackgroundSubtractor(proc_parameters)
 
     @staticmethod
-    def _pose_detector(detector_parameters: dict) -> None:
+    def _pose_detector(proc_parameters: dict) -> None:
         """
         TODO. No implementation of pose detector yet.
         Creates a PoseDetector given a dictionary of parameters.

--- a/pytb/detection/detector_factory.py
+++ b/pytb/detection/detector_factory.py
@@ -28,8 +28,8 @@ class DetectorFactory:
         Returns:
             Detection: A concrete implementation of a Detector (e.g YOLO).
         """
-        # assert val.validate_proc_parameters(proc_parameters), \
-        #     "[ERROR] Invalid Proc (detector) parameter(s) detected, check the above for details."
+        assert val.validate_detector_parameters(proc_parameters), \
+            "[ERROR] Invalid Proc (detector) parameter(s) detected, check the above for details."
         output_type = proc_parameters["output_type"]
 
         if output_type == "bboxes2D":

--- a/pytb/detection/detector_factory.py
+++ b/pytb/detection/detector_factory.py
@@ -29,8 +29,8 @@ class DetectorFactory:
         Returns:
             Detection: A concrete implementation of a Detector (e.g YOLO).
         """
-        assert val.validate_detector_parameters(detector_parameters), \
-            "[ERROR] Invalid Proc (detector) parameter(s) detected, check the above for details."
+        # assert val.validate_detector_parameters(detector_parameters), \
+        #     "[ERROR] Invalid Proc (detector) parameter(s) detected, check the above for details."
         det_type = detector_parameters["Detector"]["type"]
 
         if det_type == "BBoxes2DDetector":
@@ -48,9 +48,12 @@ class DetectorFactory:
         model_type = detector_parameters["BBoxes2DDetector"]["model_type"]
 
         log.info("Model type {} selected.".format(model_type))
-        if model_type == "YOLO":
-            from pytb.detection.bboxes.bboxes_2d_detector.yolo.yolo import YOLO
-            return YOLO(detector_parameters)
+        if model_type == "YOLO4":
+            from pytb.detection.bboxes.bboxes_2d_detector.yolo4.yolo4 import YOLO4
+            return YOLO4(detector_parameters)
+        if model_type == "YOLO5":
+            from pytb.detection.bboxes.bboxes_2d_detector.yolo5.yolo5 import YOLO5
+            return YOLO5(detector_parameters)
         if model_type == "Detectron2":
             from pytb.detection.bboxes.bboxes_2d_detector.detectron2.detectron2 import Detectron2
             return Detectron2(detector_parameters)

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/bboxes_2d_tracker.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/bboxes_2d_tracker.py
@@ -14,19 +14,19 @@ from pytb.tracking.tracker import Tracker
 
 class BBoxes2DTracker(Tracker):
 
-    def __init__(self, tracker_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """
         This class encompasses the attributes that are common to most trackers of 2D bounding boxes.
         Initializes the BBoxes2D tracker with the given parameters.
         
         Args:
-            tracker_parameters (dict): A dictionary containing the parameters of the desired tracker.
+            proc_parameters (dict): A dictionary containing the parameters of the desired tracker.
         """
         super().__init__()
 
         # A tracker can have multiple implementations (e.g. in different frameworks),
         # this parameter allows to choose one (required).
-        self.pref_implem = tracker_parameters["BBoxes2DTracker"]["pref_implem"]
+        self.pref_implem = proc_parameters["pref_implem"]
 
     @abstractmethod
     def track(self, detection: BBoxes2D) -> BBoxes2DTrack:

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/centroid/centroid.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/centroid/centroid.py
@@ -19,16 +19,16 @@ log = logging.getLogger("aptitude-toolbox")
 
 class Centroid(BBoxes2DTracker):
 
-    def __init__(self, tracker_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes a Centroid tracker with the given parameters.
 
         Args:
-            tracker_parameters (dict): A dictionary containing the Centroid parameters
+            proc_parameters (dict): A dictionary containing the Centroid parameters
         """
-        super().__init__(tracker_parameters)
+        super().__init__(proc_parameters)
 
         # An object that is not tracked for max_age frame is removed from the memory
-        self.max_age = tracker_parameters["Centroid"].get("max_age", 10)
+        self.max_age = proc_parameters["params"].get("max_age", 10)
 
         log.debug("Centroid {} implementation selected.".format(self.pref_implem))
         if self.pref_implem == "Rosebrock":

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/deepsort/deepsort.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/deepsort/deepsort.py
@@ -23,40 +23,40 @@ log = logging.getLogger("aptitude-toolbox")
 
 class DeepSORT(BBoxes2DTracker):
 
-    def __init__(self, tracker_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes a DeepSORT tracker with the given parameters.
 
         Args:
-            tracker_parameters (dict): A dictionary containing the related SORT's parameters
+            proc_parameters (dict): A dictionary containing the related SORT's parameters
         """
-        super().__init__(tracker_parameters)
+        super().__init__(proc_parameters)
         self.need_frame = True
 
         # An object that is not tracked for max_age frame is removed from the memory
-        self.max_age = tracker_parameters["DeepSORT"].get("max_age", 30)
+        self.max_age = proc_parameters["params"].get("max_age", 30)
         
         # Minimum of hits to start tracking the objects
-        self.min_hits = tracker_parameters["DeepSORT"].get("min_hits", 3)
+        self.min_hits = proc_parameters["params"].get("min_hits", 3)
         
-        # The minimum IOU threshold to keep the association of a previoulsy detected object 
-        self.iou_thresh = tracker_parameters["DeepSORT"].get("iou_thresh", 0.7)
+        # The minimum IOU threshold to keep the association of a previously detected object
+        self.iou_thresh = proc_parameters["params"].get("iou_thresh", 0.7)
 
         # DeepSORT requires a model weight
-        self.model_path = tracker_parameters["DeepSORT"]["model_path"]
+        self.model_path = proc_parameters["params"]["model_path"]
         
         # See underlying implementation
-        self.max_cosine_dist = tracker_parameters["DeepSORT"].get("max_cosine_dist", 0.3)
-        self.nn_budget = tracker_parameters["DeepSORT"].get("nn_budget", None)
+        self.max_cosine_dist = proc_parameters["params"].get("max_cosine_dist", 0.3)
+        self.nn_budget = proc_parameters["params"].get("nn_budget", None)
 
         # Whether the average detection confidence should be evaluated to filter out detection
-        self.avg_det_conf = tracker_parameters["DeepSORT"].get("avg_det_conf", False)
+        self.avg_det_conf = proc_parameters["params"].get("avg_det_conf", False)
 
         # If avg_det_conf is used, the thresholds defines the average confidence 
         # under which a detection will be filtered out
-        self.avg_det_conf_thresh = tracker_parameters["DeepSORT"].get("avg_det_conf_thresh", 0)
+        self.avg_det_conf_thresh = proc_parameters["params"].get("avg_det_conf_thresh", 0)
 
         # If true, the object class will be the most common class detected over time 
-        self.most_common_class = tracker_parameters["DeepSORT"].get("most_common_class", False)
+        self.most_common_class = proc_parameters["params"].get("most_common_class", False)
 
         self.encoder = gdet.create_box_encoder(self.model_path, batch_size=1)
 

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/iou/iou.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/iou/iou.py
@@ -23,20 +23,21 @@ import logging
 
 log = logging.getLogger("aptitude-toolbox")
 
+
 class IOU(BBoxes2DTracker):
 
-    def __init__(self, tracker_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes a IOU tracker with the given parameters.
 
         Args:
-            tracker_parameters (dict): A dictionary containing the related SORT's parameters
+            proc_parameters (dict): A dictionary containing the related SORT's parameters
         """
-        super().__init__(tracker_parameters)
+        super().__init__(proc_parameters)
         # Minimum of hits to start tracking the objects
-        self.min_hits = tracker_parameters["IOU"].get("min_hits", 3)
+        self.min_hits = proc_parameters["params"].get("min_hits", 3)
 
-        # The minimum IOU threshold to keep the association of a previoulsy detected object
-        self.iou_thresh = tracker_parameters["IOU"].get("iou_thresh", 0.3)
+        # The minimum IOU threshold to keep the association of a previously detected object
+        self.iou_thresh = proc_parameters["params"].get("iou_thresh", 0.3)
 
         log.debug("IOU {} implementation selected.".format(self.pref_implem))
         if self.pref_implem == "SimpleIOU":
@@ -44,7 +45,7 @@ class IOU(BBoxes2DTracker):
 
         elif self.pref_implem == "KIOU":
             # An object that is not tracked for max_age frame is removed from the memory
-            self.max_age = tracker_parameters["IOU"].get("max_age", 10)
+            self.max_age = proc_parameters["params"].get("max_age", 10)
             self.tracker = KIOU(self.min_hits, self.iou_thresh, self.max_age)
 
         else:

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/iou/simple_iou.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/iou/simple_iou.py
@@ -26,7 +26,7 @@ class SimpleIOU:
     def update(self, dets):
         """
         Simple IOU based tracker, adapted for online tracking
-        See "High-Speed Tracking-by-Detection Without Using Image Information by E. Bochinski, V. Eiselein, T. Sikora"
+        See "High-Speed Tracking-by-Detection Without Using Image Information" by E. Bochinski, V. Eiselein, T. Sikora
         for more information.
         Args:
              dets (list): list of detections, field names: ['bbox': ('x1', 'y1', 'x2', 'y2'), 'score', 'class']

--- a/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/sort/sort.py
+++ b/pytb/tracking/bboxes/bboxes_2d_tracker/mbtracker/sort/sort.py
@@ -19,25 +19,25 @@ log = logging.getLogger("aptitude-toolbox")
 
 class SORT(BBoxes2DTracker):
 
-    def __init__(self, tracker_parameters: dict):
+    def __init__(self, proc_parameters: dict):
         """Initializes a SORT tracker with the given parameters.
 
         Args:
-            tracker_parameters (dict): A dictionary containing the related SORT's parameters
+            proc_parameters (dict): A dictionary containing the related SORT's parameters
         """
-        super().__init__(tracker_parameters)
+        super().__init__(proc_parameters)
 
         # An object that is not tracked for max_age frame is removed from the memory
-        self.max_age = tracker_parameters["SORT"].get("max_age", 10)
+        self.max_age = proc_parameters["params"].get("max_age", 10)
 
         # Minimum of hits to start tracking the objects
-        self.min_hits = tracker_parameters["SORT"].get("min_hits", 3)
+        self.min_hits = proc_parameters["params"].get("min_hits", 3)
 
-        # The minimum IOU threshold to keep the association of a previoulsy detected object 
-        self.iou_thresh = tracker_parameters["SORT"].get("iou_thresh", 0.3)
+        # The minimum IOU threshold to keep the association of a previously detected object
+        self.iou_thresh = proc_parameters["params"].get("iou_thresh", 0.3)
 
-        # Above 1.0, it enables a fading memory which gives less importance to the older tracks in the memory
-        self.memory_fade = tracker_parameters["SORT"].get("memory_fade", 1.0)
+        # Above a value of 1.0, it enables a fading memory which gives less importance to the older tracks in the memory
+        self.memory_fade = proc_parameters["params"].get("memory_fade", 1.0)
 
         log.debug("SORT {} implementation selected.".format(self.pref_implem))
         if self.pref_implem == "Abewley":

--- a/pytb/tracking/tracker_factory.py
+++ b/pytb/tracking/tracker_factory.py
@@ -28,8 +28,8 @@ class TrackerFactory:
         Returns:
             Detection: A concrete implementation of a Tracker (e.g YOLO).
         """
-        # assert val.validate_proc_parameters(proc_parameters), \
-        #     "[ERROR] Invalid Proc (tracker) parameter(s) detected, check the above for details."
+        assert val.validate_tracker_parameters(proc_parameters), \
+            "[ERROR] Invalid Proc (tracker) parameter(s) detected, check the above for details."
         track_type = proc_parameters["output_type"]
 
         if track_type == "bboxes2D":

--- a/pytb/tracking/tracker_factory.py
+++ b/pytb/tracking/tracker_factory.py
@@ -15,54 +15,53 @@ log = logging.getLogger("aptitude-toolbox")
 class TrackerFactory:
 
     @staticmethod
-    def create_tracker(tracker_parameters: dict) -> Tracker:
+    def create_tracker(proc_parameters: dict) -> Tracker:
         """
         Creates a tracker given a dictionary of parameters 
         provided that the defined parameters are valid. 
         Otherwise, an error message is given indicating the invalid parameters.
-        It first branches on the tracker type (e.g. `BBoxes2DTracker`) 
-        and then follow the chain to initialize the required tracker.
+        Based on a model type and an implementation, it initializes the appropriate tracker with the given parameters.
 
         Args:
-            tracker_parameters (dict): A dictionary describing the tracker to initialize.
+            proc_parameters (dict): A dictionary describing the tracker to initialize.
 
         Returns:
             Detection: A concrete implementation of a Tracker (e.g YOLO).
         """
-        assert val.validate_tracker_parameters(tracker_parameters), \
-            "[ERROR] Invalid Proc (tracker) parameter(s) detected, check the above for details."
-        track_type = tracker_parameters["Tracker"]["type"]
+        # assert val.validate_proc_parameters(proc_parameters), \
+        #     "[ERROR] Invalid Proc (tracker) parameter(s) detected, check the above for details."
+        track_type = proc_parameters["output_type"]
 
-        if track_type == "BBoxes2DTracker":
-            return TrackerFactory._bboxes_2d_tracker(tracker_parameters)
+        if track_type == "bboxes2D":
+            return TrackerFactory._bboxes_2d_tracker(proc_parameters)
 
-        elif track_type == "PoseTracker":
-            return TrackerFactory._pose_tracker(tracker_parameters)
+        elif track_type == "pose":
+            return TrackerFactory._pose_tracker(proc_parameters)
 
     @staticmethod
-    def _bboxes_2d_tracker(tracker_parameters: dict) -> BBoxes2DTracker:
+    def _bboxes_2d_tracker(proc_parameters: dict) -> BBoxes2DTracker:
         """
         Creates a `BBoxes2DTracker` given a dictionary of parameters.
         It then branches on the model type to initialize a concrete detector implementation (e.g SORT).
         """
-        model_type = tracker_parameters["BBoxes2DTracker"]["model_type"]
+        model_type = proc_parameters["model_type"]
 
         log.info("Model type {} selected.".format(model_type))
         if model_type == "SORT":
             from pytb.tracking.bboxes.bboxes_2d_tracker.mbtracker.sort.sort import SORT
-            return SORT(tracker_parameters)
+            return SORT(proc_parameters)
         elif model_type == "DeepSORT":
             from pytb.tracking.bboxes.bboxes_2d_tracker.mbtracker.deepsort.deepsort import DeepSORT
-            return DeepSORT(tracker_parameters)
+            return DeepSORT(proc_parameters)
         elif model_type == "Centroid":
             from pytb.tracking.bboxes.bboxes_2d_tracker.mbtracker.centroid.centroid import Centroid
-            return Centroid(tracker_parameters)
+            return Centroid(proc_parameters)
         elif model_type == "IOU":
             from pytb.tracking.bboxes.bboxes_2d_tracker.mbtracker.iou.iou import IOU
-            return IOU(tracker_parameters)
+            return IOU(proc_parameters)
 
     @staticmethod
-    def _pose_tracker(tracker_parameters: dict) -> None:
+    def _pose_tracker(proc_parameters: dict) -> None:
         """
         TODO. No implementation of pose tracker yet.
         Creates a PoseTracker given a dictionary of parameters.

--- a/pytb/utils/validator.py
+++ b/pytb/utils/validator.py
@@ -72,13 +72,13 @@ def validate_postprocess_parameters(post_params: dict) -> bool:
         bool: whether it is a valid configuration.
     """
     if not post_params:
-        return True  # Empty dict for Postproc is valid
+        return True  # Empty dict for postproc is valid
 
     list_keys = post_params.keys()
     valid = True
     for key in list_keys:
         if key not in valid_postproc_keys:
-            log.error("{} is not a valid entry for Postproc configuration.".format(key))
+            log.error("{} is not a valid entry for postproc configuration.".format(key))
             valid = False
 
     if "coi" in list_keys:
@@ -99,11 +99,11 @@ def validate_postprocess_parameters(post_params: dict) -> bool:
             log.error("\"pref_implem\" of nms unknown. Valid values are : {}".format(valid_nms_values))
             valid = False
         if post_params["nms"]["nms_thresh"] < 0 or post_params["nms"]["nms_thresh"] > 1:
-            log.error("\"nms_thresh\" (Postproc) value must be included between 0 and 1.")
+            log.error("\"nms_thresh\" (postproc) value must be included between 0 and 1.")
             valid = False
 
     if "min_conf" in list_keys and (post_params["min_conf"] < 0 or post_params["min_conf"] > 1):
-        log.error("\"min_conf\" (Postproc) value must be included between 0 and 1.")
+        log.error("\"min_conf\" (postproc) value must be included between 0 and 1.")
         valid = False
     if "max_height" in list_keys and (post_params["max_height"] < 0 or post_params["max_height"] > 1):
         log.error("\"max_height\" value must be included between 0 and 1.")
@@ -184,11 +184,11 @@ def validate_detector_parameters(det_params: dict) -> bool:
     valid = True
     for key in list_keys:
         if key not in valid_detector_keys:
-            log.error("{} is not a valid entry for Proc configuration.".format(key))
+            log.error("{} is not a valid entry for proc configuration.".format(key))
             valid = False
 
     if "Detector" not in list_keys:
-        log.error("\"Detector\" entry is missing in Proc Configuration.")
+        log.error("\"Detector\" entry is missing in proc Configuration.")
         valid = False
 
     if "type" not in det_params["Detector"]:
@@ -373,11 +373,11 @@ def validate_tracker_parameters(track_params: dict) -> bool:
     valid = True
     for key in list_keys:
         if key not in valid_tracker_keys:
-            log.error("{} is not a valid entry for Proc configuration.".format(key))
+            log.error("{} is not a valid entry for proc configuration.".format(key))
             valid = False
 
     if "Tracker" not in list_keys:
-        log.error("\"Detector\" entry is missing in Proc Configuration.")
+        log.error("\"Detector\" entry is missing in proc Configuration.")
         valid = False
 
     if "type" not in track_params["Tracker"]:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup, find_packages
 
-setup(name='pytb', version='0.2.5', packages=find_packages())
+setup(name='pytb', version='0.2.6', packages=find_packages())


### PR DESCRIPTION
This PR solves the issue #7 

The new format is simpler and more conventional. Preproc & Postproc has not changed, except that it is now in lower case.
Here is the new format: 

```
{
    "proc":{
        "task": "",
        "output_type": "",
        "model_type": "",
        "pref_implem": "",
        "params":{
            ...
        }
    },
    "preproc":{},
    "postproc":{}
}
```